### PR TITLE
Replaced outdated method in Reflection page of lesson 22/24 

### DIFF
--- a/trysmalltalk/st/TrySmalltalk.st
+++ b/trysmalltalk/st/TrySmalltalk.st
@@ -679,8 +679,11 @@ ProfStef methodDictionary.
 "Let''s create a new method to go to the next lesson:"
 
 |newMethod|
-newMethod := Compiler new load: ''goToNextLesson ProfStef next.'' forClass: ProfStef.
-ProfStef class addCompiledMethod: newMethod
+newMethod := Compiler new 
+	install: ''goToNextLesson ProfStef next.'' 
+	forClass: ProfStef 
+	category: ''navigation''.
+ProfStef class addCompiledMethod: newMethod.
 
 "Wow!! I can''t wait to use my new method!!"
 


### PR DESCRIPTION
In Reflection page of lesson 22/24 replace outdated #load:forClass:  with  #install:forClass:category:

Let me know if I need to supply an updated .js file as well before you accept the pull request.
